### PR TITLE
KSIJS-37 - Use new Uint8Array(..) instead of Uint8Array.from(..) to fix core-js' Safari polyfill.

### DIFF
--- a/src/hash/DataHash.ts
+++ b/src/hash/DataHash.ts
@@ -23,7 +23,7 @@ export default class DataHash implements IDataHash {
     }
 
     this.hashAlgorithm = algorithm;
-    this.imprint = Uint8Array.from(bytes);
+    this.imprint = new Uint8Array(bytes);
     this.value = this.imprint.slice(1);
     if (this.value.length != this.hashAlgorithm.length) {
       throw new HashingError(


### PR DESCRIPTION
https://github.com/zloirock/core-js/issues/285 is a reference to the root cause and workaround fix of using the constructor.